### PR TITLE
[22] Create an option to prevent infinite obsidian cycles

### DIFF
--- a/terumet/machine/vulcan.lua
+++ b/terumet/machine/vulcan.lua
@@ -93,19 +93,23 @@ function base_vul.check_new_processing(vulcan)
     local in_inv, in_list = base_mach.get_input(vulcan)
     for slot = 1,in_inv:get_size(in_list) do
         local input_stack = in_inv:get_stack(in_list, slot)
-        local matched_recipe = opts.recipes[input_stack:get_name()]
+        local source = input_stack:get_name()
+        local matched_recipe = opts.recipes[source]
         if matched_recipe then
+            local result = matched_recipe[1]
             local yield = matched_recipe[2]
             vulcan.state = base_vul.STATE.VULCANIZING
             vulcan.state_time = opts.PROCESS_TIME
             vulcan.heat_cost = opts.COST_VULCANIZE
-            if base_mach.has_upgrade(vulcan, 'cryst') then
+            -- if limited, obsidian will not benefit from crystalization upgrade
+            local limit_obsidian = opts.LIMIT_OBSIDIAN and source == 'default:obsidian'
+            if not limit_obsidian and base_mach.has_upgrade(vulcan, 'cryst') then
                 yield = yield + 1
                 vulcan.state_time = vulcan.state_time * 3
                 vulcan.heat_cost = vulcan.heat_cost * 2
             end
             in_inv:remove_item(in_list, input_stack:get_name())
-            vulcan.inv:set_stack('result', 1, matched_recipe[1] .. ' ' .. yield)
+            vulcan.inv:set_stack('result', 1, result .. ' ' .. yield)
             vulcan.status_text = 'Accepting ' .. input_stack:get_definition().description .. ' for vulcanizing...'
             return
         end

--- a/terumet/material/crystallized.lua
+++ b/terumet/material/crystallized.lua
@@ -1,4 +1,5 @@
 local id=terumet.id
+local opts = terumet.options.vulcan
 
 local crys_terumetal = terumet.register_crystal{
     suffix='raw',
@@ -51,7 +52,11 @@ local crys_ob = terumet.register_crystal{
     name='Crystallized Obsidian',
     cooking_result='default:obsidian'
 }
-terumet.register_vulcan_result('default:obsidian', crys_ob)
+if opts.LIMIT_OBSIDIAN then
+    terumet.register_vulcan_result('default:obsidian', crys_ob, -1)
+else
+    terumet.register_vulcan_result('default:obsidian', crys_ob)
+end
 
 local crys_mese = terumet.register_crystal{
     suffix='mese',

--- a/terumet/options.lua
+++ b/terumet/options.lua
@@ -309,6 +309,9 @@ terumet.options.vulcan = {
     COST_VULCANIZE = 10,
     -- Time to process one item (in seconds)
     PROCESS_TIME = 6.0,
+    -- when true, crystalizing obsidian always produces exactly one crystal.
+    -- this prevents easy infinite obsidian loops.
+    LIMIT_OBSIDIAN = true,
 }
 
 terumet.options.lavam = {


### PR DESCRIPTION
Fix for issue #22 . 

Currently it defaults to limiting obsidian crystalization to one crystal, but the default matters less to me than the ability to limit it at all.

I've tested crystalizing obsidian and a couple other things with and without the option enabled, and it behaves as I'd expect.