### PR TITLE
Ensure ore saw respects protection

### DIFF
--- a/terumet/tool/ore_saw.lua
+++ b/terumet/tool/ore_saw.lua
@@ -12,7 +12,7 @@ minetest.register_tool( saw_id, {
         if pointed_thing.type == 'node' and pointed_thing.under then
             local npos = pointed_thing.under
             local node_id = minetest.get_node(npos).name
-            if opts.VALID_ORES[node_id] then
+            if opts.VALID_ORES[node_id] and not minetest.is_protected(npos, user:get_player_name()) then
                 terumet.give_player_item(user.pos, user, node_id)
                 minetest.remove_node(npos)
                 minetest.sound_play( 'terumet_saw', {


### PR DESCRIPTION
Currently the ore saw lets any player harvest any valid ore node, even if it is in someone else's protected area. 
This change makes it respect protection. Players can still use the ore saw in their own protected areas, or open areas, but not closed protected areas of another player. 