### PR TITLE
Tubelib 2.0 support for tube upgrade

### DIFF
--- a/terumet/interop/tubelib.lua
+++ b/terumet/interop/tubelib.lua
@@ -1,4 +1,8 @@
-terumet.register_machine_upgrade('tubelib', 'Tube Support Upgrade', 'tubelib:tube1', nil, 'single')
+if tubelib.version < 2.0 then
+    terumet.register_machine_upgrade('tubelib', 'Tube Support Upgrade', 'tubelib:tube1', nil, 'single')
+else
+    terumet.register_machine_upgrade('tubelib', 'Tube Support Upgrade', 'tubelib:tubeS', nil, 'single')
+end
 
 local machine_check = function(machine, player_name)
     return machine and terumet.machine.has_upgrade(machine, 'tubelib')


### PR DESCRIPTION
Tubelib changed the id of a tube in 2.0, so the old recipe is uncraftable. This update checks the tubelib version and uses the appropriate tube. 