### PR TITLE
armor stat updates

### DIFF
--- a/terumet/interop/armor.lua
+++ b/terumet/interop/armor.lua
@@ -29,14 +29,14 @@ end
 local function reg_recipe_legs(id, mat)
     minetest.register_craft{output=id, recipe={
         {mat, mat, mat},
-        {mat, '', mat},
-        {mat, '', mat}
+        {mat, '',  mat},
+        {mat, '',  mat}
     }}
 end
 
 local function reg_recipe_chest(id, mat)
     minetest.register_craft{output=id, recipe={
-        {mat, '', mat},
+        {mat, '',  mat},
         {mat, mat, mat},
         {mat, mat, mat}
     }}
@@ -45,7 +45,7 @@ end
 local function reg_recipe_helm(id, mat)
     minetest.register_craft{output=id, recipe={
         {mat, mat, mat},
-        {mat, '', mat},
+        {mat, '',  mat},
     }}
 end
 
@@ -69,7 +69,7 @@ local function reg_terumet_armor(data)
 
     data.heal = data.total_heal / 4
     data.speed = data.weight / -100
-    data.gravity = data.weight / 200
+    data.gravity = data.weight / 50
 
     local boots_id = terumet.id('armboots_'..data.suffix)
     armor:register_armor(boots_id, {
@@ -205,18 +205,17 @@ if opts.BRACERS then
     end
 end
 
-reg_terumet_armor{suffix='tcop', name='Terucopper', mat=terumet.id('ingot_tcop'), mrv=20,
-    total_def=45, total_heal=4, weight=0, uses=1400}
-reg_terumet_armor{suffix='ttin', name='Terutin', mat=terumet.id('ingot_ttin'), mrv=21,
-    total_def=38, total_heal=24, weight=-2, xinfo='Weight -2', uses=1000}
-reg_terumet_armor{suffix='tste', name='Terusteel', mat=terumet.id('ingot_tste'), mrv=40,
-    total_def=56, total_heal=12, weight=1, xinfo='Weight +1', uses=2000}
-reg_terumet_armor{suffix='tcha', name='Teruchalcum', mat=terumet.id('ingot_tcha'), mrv=60,
-    total_def=64, total_heal=8, weight=2, xinfo='Weight +2', uses=1500}
-reg_terumet_armor{suffix='tgol', name='Terugold', mat=terumet.id('ingot_tgol'), mrv=80,
-    total_def=24, total_heal=65, weight=-1, xinfo='Weight -1', uses=600}
-reg_terumet_armor{suffix='cgls', name='Coreglass', mat=terumet.id('ingot_cgls'), mrv=120,
-    total_def=78, total_heal=36, weight=3, xinfo='Weight +3', uses=3000}
-
-reg_terumet_armor{suffix='rsuit', name='Vulcansuit', mat=terumet.id('item_rsuitmat'), mrv=180,
-    total_def=78, total_heal=50, weight=-5, xinfo='Weight -5', uses=3000}
+reg_terumet_armor{suffix='cgls', name='Coreglass',   mat=terumet.id('ingot_cgls'),
+    mrv=120, total_def=78, total_heal=36, weight=3, xinfo='Weight +3',  uses=120, fire=15}
+reg_terumet_armor{suffix='tcha', name='Teruchalcum', mat=terumet.id('ingot_tcha'),
+    mrv=60,  total_def=64, total_heal=8,  weight=2, xinfo='Weight +2',  uses=260}
+reg_terumet_armor{suffix='tste', name='Terusteel',   mat=terumet.id('ingot_tste'),
+    mrv=40,  total_def=56, total_heal=12, weight=1, xinfo='Weight +1',  uses=190}
+reg_terumet_armor{suffix='tcop', name='Terucopper',  mat=terumet.id('ingot_tcop'),
+    mrv=20,  total_def=45, total_heal=4,  weight=0,                     uses=280}
+reg_terumet_armor{suffix='tgol', name='Terugold',    mat=terumet.id('ingot_tgol'),
+    mrv=80,  total_def=24, total_heal=65, weight=-1, xinfo='Weight -1', uses=720}
+reg_terumet_armor{suffix='ttin', name='Terutin',     mat=terumet.id('ingot_ttin'),
+    mrv=21,  total_def=38, total_heal=24, weight=-2, xinfo='Weight -2', uses=410, fire=10, breathing=.1}
+reg_terumet_armor{suffix='rsuit', name='Vulcansuit', mat=terumet.id('item_rsuitmat'),
+    mrv=180, total_def=78, total_heal=50, weight=-3, xinfo='Weight -3', uses=120, fire=20}

--- a/terumet/material/coalproc.lua
+++ b/terumet/material/coalproc.lua
@@ -66,7 +66,7 @@ minetest.register_craftitem( rsuit_mat, {
     inventory_image = terumet.tex(rsuit_mat)
 })
 
-terumet.register_alloy_recipe{result=rsuit_mat, flux=8, time=10.0, input={rubber_bar_id, 'terumet:ingot_cgls'}}
+terumet.register_alloy_recipe{result=rsuit_mat, flux=8, time=20.0, input={rubber_bar_id, 'terumet:item_thermese', 'terumet:item_ceramic'}}
 
 local asphalt_id = terumet.id('block_asphalt')
 

--- a/terumet/options.lua
+++ b/terumet/options.lua
@@ -479,20 +479,27 @@ terumet.options.armor = {
     -- delete or comment out entire BRACERS = {...} block to disable all bracers
     BRACERS = { -- delete single line or comment out (add -- to start) to disable that type of bracer
         -- water-breathing bracer
-        aqua={name='Aqua', color='#0010ff', mat='default:papyrus', xinfo='Underwater breathing', def=5, uses=500, rep=100, breathing=1},
+        aqua={name='Aqua',        color='#0010ff', mat='default:papyrus',         xinfo='Underwater breathing',
+              def=5,   uses=500, rep=100, breathing=1},
         -- high jump bracer
-        jump={name='Jump', color='#ffac00', mat='terumet:item_cryst_mese', xinfo='Increase jump height', def=5, uses=500, rep=150, jump=0.32},
+        jump={name='Jump',        color='#ffac00', mat='terumet:item_cryst_mese', xinfo='Increase jump height',
+              def=5,   uses=500, rep=150, jump=0.5},
         -- movement speed bracer
-        spd={name='Speed', color='#4eff00', mat='terumet:item_cryst_dia', xinfo='Increase move speed', def=5, uses=300, rep=400, speed=0.4},
+        spd={ name='Speed',       color='#4eff00', mat='terumet:item_cryst_dia',  xinfo='Increase move speed',
+              def=5,   uses=300, rep=400, speed=0.8},
         -- anti-gravity bracer
-        agv={name='Antigravity', color='#7600ff', mat='terumet:item_entropy', xinfo='Reduce gravity', def=5, uses=600, rep=300, speed=-0.05, gravity=-0.4, jump=-0.25},
+        agv={ name='Antigravity', color='#7600ff', mat='terumet:item_entropy',    xinfo='Reduce gravity',
+              def=5,   uses=600, rep=300, speed=-0.1, gravity=-0.5, jump=-0.1},
         -- high heal bracer
-        heal={name='Heal', color='#ff0086', mat='terumet:block_dust_bio', xinfo='Heal +30', heal=30, uses=200, rep=600},
+        heal={name='Heal',        color='#ff0086', mat='terumet:block_dust_bio',  xinfo='Heal +10',
+              heal=10, uses=600, rep=600},
         -- high defense bracer
-        def={name='Defense', color='#727272', mat='terumet:item_rsuitmat', xinfo='Defense +30', def=33, uses=1000, rep=300},
+        def={ name='Defense',     color='#727272', mat='terumet:item_rsuitmat',   xinfo='Defense +30',
+              def=30,  uses=300, rep=300},
         -- fire protection bracer
         -- IMPORTANT: 3darmor must have the option "Enable fire protection" on in order for this bracer to function!
-        fire={name='Fireproof', color='#ff5d00', mat='terumet:item_cryst_ob', xinfo='Immunity to fire/lava', uses=500, rep=300, fire=99},
+        fire={name='Fireproof',   color='#ff5d00', mat='terumet:item_cryst_ob',   xinfo='Immunity to fire/lava',
+                       uses=500, rep=300, fire=99},
     },
     -- Item used to create bracer crystals
     BRACER_CRYSTAL_ITEM = 'default:steelblock',


### PR DESCRIPTION
I spent some time and tweaked the stats of the armor/bracers so that the jump/antigrav boosts from armor are both useful and not absurd. I also tweaked a couple other things, which I'll explain below.

Here is a table demonstrating the jump heights in the current head, and in this PR. Note that jump values are quantized at the values (N, N+1/16, N+1/8, N+1/4, N+1/2, N+3/4, N+7/8, N+15/16), because that's what moreblocks gives me, and I didn't want to code special blocks and felt that was enough for this test.

|      | naked | steel | gold  | coreglass | teruchalcum | terusteel | terucopper | terugold | terutin | vulcansuit |
| ---- | ----- | ----- | ----- | --------- | ----------- | --------- | ---------- | -------- | ------- | ---------- |
| head | 1.25  | 1.125 | 1.125 | 1.25      | 1.25        | 1.25      | 1.25       | 1.25     | 1.25    | 1.25       |
| PR   | 1.25  | 1.125 | 1.125 | 1.0625    | 1.125       | 1.125     | 1.25       | 1.25     | 1.5     | 2.0625     |

Here is a table for certain armors when combined with an antigrav bracer:

|      | naked | terugold | terutin | vulcansuit |
| ---- | ----- | -------- | ------- | ---------- |
| head | 1.25  | 1.25     | 1.25    | 1.25       |
| PR   | 2     | 2.25     | 2.75    | 3.5        |

Here is a table for certain armors when combined with a jump bracer:

|      | naked | terugold | terutin | vulcansuit |
| ---- | ----- | -------- | ------- | ---------- |
| head | 2.125 | 2.125    | 2.25    | 2.25       |
| PR   | 2.5   | 2.75     | 3       | 3.25       |
