### PR TITLE
add dependency on stamina (for load ordering)

### DIFF
--- a/terumet/depends.txt
+++ b/terumet/depends.txt
@@ -20,3 +20,4 @@ extra?
 walls?
 doors?
 stairs?
+stamina?

--- a/terumet/mod.conf
+++ b/terumet/mod.conf
@@ -1,4 +1,4 @@
 name=terumet
 description=Terumetal v3.0 - Make life easier with alloys and heat machinery!
 depends=default,bucket,screwdriver,farming,dye,basic_materials
-optional_depends=3d_armor,unified_inventory,tubelib,walls,stairs,doors,tnt,mesecons,dungeon_loot,bushes,dryplants,vines,mobs_animal,main,extra
+optional_depends=3d_armor,unified_inventory,tubelib,walls,stairs,doors,tnt,mesecons,dungeon_loot,bushes,dryplants,vines,mobs_animal,main,extra,stamina


### PR DESCRIPTION
Fixes #57.

Adds dependencies on the stamina mod, because of load-order-dependent behaviour. 