### PR TITLE
Keep ticking if we have an output upgrade as well as in input upgrade

### DIFF
--- a/terumet/machine/crusher.lua
+++ b/terumet/machine/crusher.lua
@@ -158,7 +158,7 @@ function base_crs.tick(pos, dt)
     -- write status back to metad
     base_mach.write_state(pos, crusher)
 
-    return crusher.state ~= base_crs.STATE.IDLE or base_mach.has_ext_input(crusher) or venting
+    return crusher.state ~= base_crs.STATE.IDLE or base_mach.has_ext_any(crusher) or venting
 end
 
 base_crs.unlit_nodedef = base_mach.nodedef{

--- a/terumet/machine/htfurnace.lua
+++ b/terumet/machine/htfurnace.lua
@@ -146,7 +146,7 @@ function base_htf.tick(pos, dt)
     -- write status back to meta
     base_mach.write_state(pos, furnace)
 
-    return working or venting or base_mach.has_ext_input(furnace)
+    return working or venting or base_mach.has_ext_any(furnace)
 end
 
 base_htf.unlit_nodedef = base_mach.nodedef{

--- a/terumet/machine/repm.lua
+++ b/terumet/machine/repm.lua
@@ -213,7 +213,7 @@ function base_repm.tick(pos, dt)
         -- if still processing and not waiting for heat, reset timer to continue processing
         reset_timer = true
         base_mach.generate_smoke(pos)
-    elseif venting or base_mach.has_ext_input(repm) then
+    elseif venting or base_mach.has_ext_any(repm) then
         reset_timer = true
     end
     -- write status back to meta

--- a/terumet/machine/vacoven.lua
+++ b/terumet/machine/vacoven.lua
@@ -138,7 +138,7 @@ function base_vov.tick(pos, dt)
     base_mach.write_state(pos, oven)
 
     -- return true to reset tick timer
-    return working or venting or base_mach.has_ext_input(oven)
+    return working or venting or base_mach.has_ext_any(oven)
 end
 
 base_vov.unlit_nodedef = base_mach.nodedef{

--- a/terumet/machine/vulcan.lua
+++ b/terumet/machine/vulcan.lua
@@ -151,7 +151,7 @@ function base_vul.tick(pos, dt)
     -- write status back to meta
     base_mach.write_state(pos, vulcan)
 
-    return (vulcan.state ~= base_vul.STATE.IDLE) or base_mach.has_ext_input(vulcan) or venting
+    return (vulcan.state ~= base_vul.STATE.IDLE) or base_mach.has_ext_any(vulcan) or venting
 end
 
 base_vul.nodedef = base_mach.nodedef{


### PR DESCRIPTION
Fixes issue #66 

We should keep looking for updates if we have any of the input/output upgrades, this stops the blocking issue without introducing any new logic. This would work if I had an input upgrade alongside the output upgrade, or if it was the combined input/output upgrade, it seems sensible that we should just do the exact same thing if it's just the output upgrade.

I'm pretty sure I got all the proper machines, Alloy Smelter already works this way, Mese Garden has no output chest, all other machines (heaters, heat transfer, lava smelter) have no output, so do not need to be considered.

I've only actually tested this on the high-temp furnace, but looking through the logic this should work for all of them.