### PR TITLE
Deny insertion while an input upgrade is installed

### DIFF
--- a/terumet/machine/generic/machine.lua
+++ b/terumet/machine/generic/machine.lua
@@ -925,6 +925,9 @@ function base_mach.allow_put(pos, listname, index, stack, player)
     elseif listname == "out" then
         -- deny insertion into output slots
         return 0
+    elseif base_mach.has_ext_input(base_mach.readonly_state(pos)) then
+        -- deny insertion while an input upgrade is installed
+        return 0
     else
         return stack:get_count()
     end


### PR DESCRIPTION
Fixes issue #68 

This behaviour can seems spooky since you cannot see the slot you are placing items into, it should simply not occur, I have disallowed it in the on_put logic

Note that this can still be achieved by placing the items first, then installing an input upgrade OR by using a tubelib upgrade in tandem with an input upgrade, and pushing the items in. These are weird cases, and probably qualify as interaction design not bugfixing, and are also much more intentional than shift-clicking items into the inventory, so are not fixed with this PR.